### PR TITLE
Add DLSS option

### DIFF
--- a/osu.Desktop/DLSSManager.cs
+++ b/osu.Desktop/DLSSManager.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using osu.Framework.Logging;
+
+namespace osu.Desktop
+{
+    [SupportedOSPlatform("windows")]
+    internal static class DLSSManager
+    {
+        public static bool Available { get; }
+
+        private static bool enabled;
+
+        static DLSSManager()
+        {
+            if (!OperatingSystem.IsWindows())
+                return;
+
+            try
+            {
+                IntPtr handle;
+                Available = NativeLibrary.TryLoad("nvngx_dlss.dll", out handle);
+                if (handle != IntPtr.Zero)
+                    NativeLibrary.Free(handle);
+            }
+            catch
+            {
+                Available = false;
+            }
+        }
+
+        public static bool Enabled
+        {
+            get => enabled;
+            set
+            {
+                if (!Available)
+                    return;
+
+                enabled = value;
+                Logger.Log($"[DLSS] {(enabled ? "Enabled" : "Disabled")}");
+                // TODO: call into DLSS APIs once available
+            }
+        }
+    }
+}

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -92,6 +92,7 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.ExternalLinkWarning, true);
             SetDefault(OsuSetting.PreferNoVideo, false);
+            SetDefault(OsuSetting.UseDLSS, false);
 
             SetDefault(OsuSetting.ShowOnlineExplicitContent, false);
 
@@ -413,6 +414,7 @@ namespace osu.Game.Configuration
         ScoreDisplayMode,
         ExternalLinkWarning,
         PreferNoVideo,
+        UseDLSS,
         Scaling,
         ScalingPositionX,
         ScalingPositionY,

--- a/osu.Game/Localisation/GraphicsSettingsStrings.cs
+++ b/osu.Game/Localisation/GraphicsSettingsStrings.cs
@@ -140,6 +140,11 @@ namespace osu.Game.Localisation
         public static LocalisableString UseHardwareAcceleration => new TranslatableString(getKey(@"use_hardware_acceleration"), @"Use hardware acceleration");
 
         /// <summary>
+        /// "Enable DLSS"
+        /// </summary>
+        public static LocalisableString EnableDlss => new TranslatableString(getKey(@"enable_dlss"), @"Enable DLSS");
+
+        /// <summary>
         /// "JPG (web-friendly)"
         /// </summary>
         public static LocalisableString Jpg => new TranslatableString(getKey(@"jpg_web_friendly"), @"JPG (web-friendly)");

--- a/osu.Game/Overlays/Settings/Sections/Graphics/VideoSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/VideoSettings.cs
@@ -9,6 +9,8 @@ using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Video;
 using osu.Framework.Localisation;
+using osu.Game.Configuration;
+using osu.Desktop;
 using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Settings.Sections.Graphics
@@ -19,17 +21,25 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
         private Bindable<HardwareVideoDecoder> hardwareVideoDecoder;
         private SettingsCheckbox hwAccelCheckbox;
+        private SettingsCheckbox dlssCheckbox;
 
         [BackgroundDependencyLoader]
-        private void load(FrameworkConfigManager config)
+        private void load(FrameworkConfigManager config, OsuConfigManager osuConfig)
         {
             hardwareVideoDecoder = config.GetBindable<HardwareVideoDecoder>(FrameworkSetting.HardwareVideoDecoder);
+            var useDlss = osuConfig.GetBindable<bool>(OsuSetting.UseDLSS);
 
             Children = new Drawable[]
             {
                 hwAccelCheckbox = new SettingsCheckbox
                 {
                     LabelText = GraphicsSettingsStrings.UseHardwareAcceleration,
+                },
+                dlssCheckbox = new SettingsCheckbox
+                {
+                    LabelText = GraphicsSettingsStrings.EnableDlss,
+                    Current = useDlss,
+                    CanBeShown = { Value = DLSSManager.Available },
                 },
             };
 
@@ -40,6 +50,11 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
             {
                 hardwareVideoDecoder.Value = val.NewValue ? HardwareVideoDecoder.Any : HardwareVideoDecoder.None;
             });
+
+            dlssCheckbox.Current.BindValueChanged(val =>
+            {
+                DLSSManager.Enabled = val.NewValue;
+            }, true);
         }
     }
 }


### PR DESCRIPTION
## Summary
- integrate a stub for DLSS support via `DLSSManager`
- add `UseDLSS` setting and default value
- expose new checkbox in Video settings
- add localisation string for "Enable DLSS"

## Testing
- `dotnet tool restore`
- `dotnet format osu.sln --no-restore` *(failed: The operation was canceled)*
- `dotnet test osu.sln --no-build` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68848f02d0bc83318242f652c427e8cc