### PR TITLE
Use app-local path for Realm fallback pipe to avoid SELinux FIFO denials

### DIFF
--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -800,7 +800,12 @@ namespace osu.Game.Database
         {
             // This is currently the only usage of temporary files at the osu! side.
             // If we use the temporary folder in more situations in the future, this should be moved to a higher level (helper method or OsuGameBase).
-            string tempPathLocation = Path.Combine(Path.GetTempPath(), @"lazer");
+            //
+            // Important: on some Android devices, app data can live on a FUSE-backed path where FIFO creation is blocked by SELinux.
+            // Realm creates FIFO lock files for interprocess communication. Ensure these are routed to an app-private location.
+            string localAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            string tempPathLocation = Path.Combine(string.IsNullOrEmpty(localAppDataPath) ? Path.GetTempPath() : localAppDataPath, @"lazer");
+
             if (!Directory.Exists(tempPathLocation))
                 Directory.CreateDirectory(tempPathLocation);
 


### PR DESCRIPTION
### Motivation
- Prevent Realm from creating FIFO lock files on FUSE/external paths that can be blocked by SELinux on some Android devices by routing `FallbackPipePath` to an app-private location.

### Description
- Change `RealmAccess.getConfiguration()` to compute `FallbackPipePath` from `Environment.SpecialFolder.LocalApplicationData` when available, falling back to `Path.GetTempPath()`, and add explanatory comments; file modified: `osu.Game/Database/RealmAccess.cs`.

### Testing
- Attempted an automated build with `dotnet build osu.Game/osu.Game.csproj -v minimal`, but the build could not be run in this environment because `dotnet` is not installed (failure due to missing tooling).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5c7b45d1883319595910657ec8350)