### PR TITLE
Update custom API setting entry to new forms style

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Online/WebSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Online/WebSettings.cs
@@ -12,6 +12,7 @@ using osu.Framework.Threading;
 using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
+using osu.Game.Online.API;
 
 namespace osu.Game.Overlays.Settings.Sections.Online
 {
@@ -19,13 +20,12 @@ namespace osu.Game.Overlays.Settings.Sections.Online
     {
         protected override LocalisableString Header => OnlineSettingsStrings.WebHeader;
 
-        [Resolved]
-        private OsuGame? game { get; set; }
+        private FormTextBox customApiUrlTextBox = null!;
 
-        private SettingsTextBox customApiUrlTextBox = null!;
+        private readonly Bindable<SettingsNote.Data?> customApiNote = new Bindable<SettingsNote.Data?>();
 
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config)
+        private void load(OsuConfigManager config, IAPIProvider api)
         {
             Children = new Drawable[]
             {
@@ -58,11 +58,16 @@ namespace osu.Game.Overlays.Settings.Sections.Online
                 {
                     Keywords = new[] { "nsfw", "18+", "offensive" }
                 },
-                customApiUrlTextBox = new SettingsTextBox
+                new SettingsItemV2(customApiUrlTextBox = new FormTextBox
                 {
-                    LabelText = OnlineSettingsStrings.CustomApiUrl,
-                    Current = config.GetBindable<string>(OsuSetting.CustomApiUrl)
-                }
+                    Caption = OnlineSettingsStrings.CustomApiUrl,
+                    Current = config.GetBindable<string>(OsuSetting.CustomApiUrl),
+                    PlaceholderText = api.Endpoints.APIUrl,
+                })
+                {
+                    Keywords = new[] { "api", "server", "custom", "endpoint" },
+                    Note = { BindTarget = customApiNote },
+                },
             };
 
             customApiUrlTextBox.Current.BindValueChanged(onCustomApiUrlChanged, true);
@@ -73,7 +78,7 @@ namespace osu.Game.Overlays.Settings.Sections.Online
         private ScheduledDelegate? pendingValidation;
         private const double debounce_delay = 500;
 
-        private static readonly Regex hostPortPattern = new Regex(
+        private static readonly Regex host_port_pattern = new Regex(
             pattern:
             @"^(?:" +
             @"(?:(?:[A-Za-z0-9-]+)\.)+[A-Za-z0-9-]+" +
@@ -86,7 +91,7 @@ namespace osu.Game.Overlays.Settings.Sections.Online
         {
             if (isInitialLoad)
             {
-                var initRaw = (e.NewValue ?? string.Empty).Trim();
+                string initRaw = e.NewValue.Trim();
                 lastApiUrl = normalizeToHttps(initRaw);
                 isInitialLoad = false;
                 return;
@@ -100,7 +105,7 @@ namespace osu.Game.Overlays.Settings.Sections.Online
                 if (string.IsNullOrWhiteSpace(rawInput))
                 {
                     maybeShowRestartIfChanged(string.Empty);
-                    customApiUrlTextBox.SetNoticeText(string.Empty, false);
+                    customApiNote.Value = null;
                     return;
                 }
 
@@ -108,19 +113,19 @@ namespace osu.Game.Overlays.Settings.Sections.Online
 
                 if (!isValidHostPort(hostPort))
                 {
-                    customApiUrlTextBox.SetNoticeText(OnlineSettingsStrings.CustomApiUrlInvalid, true);
+                    customApiNote.Value = new SettingsNote.Data(OnlineSettingsStrings.CustomApiUrlInvalid, SettingsNote.Type.Critical);
                     return;
                 }
 
                 string normalised = "https://" + hostPort;
-                customApiUrlTextBox.SetNoticeText(string.Empty, false);
+                customApiNote.Value = null;
                 maybeShowRestartIfChanged(normalised);
             }, debounce_delay);
         }
 
         private static bool isValidHostPort(string hostPort)
         {
-            var m = hostPortPattern.Match(hostPort);
+            var m = host_port_pattern.Match(hostPort);
             if (!m.Success) return false;
 
             var g = m.Groups["port"];
@@ -159,7 +164,7 @@ namespace osu.Game.Overlays.Settings.Sections.Online
             if (!string.Equals(lastApiUrl, normalizedNewValue, StringComparison.OrdinalIgnoreCase))
             {
                 lastApiUrl = normalizedNewValue;
-                customApiUrlTextBox.SetNoticeText(OnlineSettingsStrings.CustomApiUrlRestartRequired, false);
+                customApiNote.Value = new SettingsNote.Data(OnlineSettingsStrings.CustomApiUrlRestartRequired, SettingsNote.Type.Informational);
             }
         }
     }


### PR DESCRIPTION
Use the `SettingsItemV2`, `FormTextBox` to show custom API field, and `SettingsNote` for prettier prompt display.

This PR also added a placeholder text of default API endpoint for this entry.

<img width="1545" height="573" alt="141e3962fc9fdb0edb28e2af26a64bd5" src="https://github.com/user-attachments/assets/b0a47c06-f1dc-4cdb-bcdd-0a3ebac2e842" />
